### PR TITLE
doc: correct the npm badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ See also the list of [contributors](https://github.com/imgcook/imove/graphs/cont
 
 本仓库遵循 [all-contributors](https://github.com/all-contributors/all-contributors) 规范，欢迎贡献!
 
-[npm-image]: https://img.shields.io/npm/v/imgcook/imove.svg?style=flat-square
+[npm-image]: https://img.shields.io/npm/v/@imove/core.svg?style=flat-square
 [npm-url]: https://www.npmjs.com/package/@imove/core
 [travis-image]: https://img.shields.io/travis/imgcook/imove/master.svg?style=flat-square
 [travis-url]: https://travis-ci.org/imgcook/imove/


### PR DESCRIPTION
当前 README 中的 npm badge 错误，应该在 URL 中使用 npm name :)