### PR TITLE
fix: 通用元件父容器宽度、文档错误

### DIFF
--- a/README.en-US.md
+++ b/README.en-US.md
@@ -33,8 +33,9 @@ Download this project, install dependencies and start the project.
 $ git clone https://github.com/imgcook/imove.git
 $ npm run example
 ```
-
+<!-- markdown-link-check-disable -->
 Open http://localhost:8000/ and you can see the online effect.
+<!-- markdown-link-check-enable -->
 
 ### Step2. Draw flowchart
 

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -20,7 +20,7 @@
 
 - [x] **Process visualization:** iMove is easy to use and easy to draw. Its logical expression is more intuitive and easy to understand.
 - [x] **Logic re-usage:** iMove node supports multiplexing, and its single node supports parameter configuration.
-- [x] **Flexible**: We need to write an only function. The node can also be extended. iMove can alse support plug-in integration.
+- [x] **Flexible**: We need to write an only function. The node can also be extended. iMove can also support plug-in integration.
 - [ ] **Multi-language compilation**: There is no language compiling code limitation (example: support JavaScript, Java compiling code).
 
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ $ npm install
 $ npm run example
 ```
 
+<!-- markdown-link-check-disable -->
 此时浏览器会自动打开 `http://localhost:8000/` ，可以看到运行效果。
+<!-- markdown-link-check-enable -->
 
 ### 步骤 2. 绘制流程图
 

--- a/packages/core/src/mods/sideBar/index.module.less
+++ b/packages/core/src/mods/sideBar/index.module.less
@@ -1,5 +1,4 @@
 .container {
-
   width: 100%;
 
   :global {
@@ -16,4 +15,5 @@
 
 .chart {
   width: 100%;
+  min-width: 201px;
 }


### PR DESCRIPTION
- [x] 调整通用元件父容器宽度，解决**处理**元件显示不全的问题[1]。
- [x] 文档单词拼错；
- [x] 禁用检查 `localhost` 的可访问性。

![image](https://user-images.githubusercontent.com/2106987/104815179-f6b95800-584d-11eb-94ce-e407750ea02d.png)

[1] https://github.com/imgcook/imove/issues/56#issuecomment-761302831