### PR TITLE
fix: add key

### DIFF
--- a/packages/core/src/components/schemaForm/index.tsx
+++ b/packages/core/src/components/schemaForm/index.tsx
@@ -91,6 +91,7 @@ const SchemaForm: React.FC<IProps> = (props) => {
           return <FormItem
             label={obj.title}
             name={key}
+            key={key}
           >
             {ele}
           </FormItem>


### PR DESCRIPTION
双击节点后，控制台报错，缺少 `key` 🚀