### PR TITLE
fix: fr-generate 右侧图标展开后位置不对的问题修复

### DIFF
--- a/packages/core/src/mods/settingBar/components/json/index.module.less
+++ b/packages/core/src/mods/settingBar/components/json/index.module.less
@@ -19,6 +19,12 @@
       height:600px;
       overflow-y: auto;
       margin:0 20px;
+
+      :global {
+        .fr-wrapper {
+          position: relative;
+        }
+      }
     }
     .configInput{
       height: 600px;


### PR DESCRIPTION
[![sIbm28.png](https://s3.ax1x.com/2021/01/22/sIbm28.png)](https://imgchr.com/i/sIbm28)

看了一下是 `.fr-wrapper` 加一个 `position: relative;`，这样绝对定位的时候就能找到正确的相对位置了，但是这个可以在 `fr-generate` 这个库里改，我这儿直接通过选择器给加上了